### PR TITLE
Fix for decodeEntities when parsing an html string in parts

### DIFF
--- a/ksoup-html/src/commonMain/kotlin/com/mohamedrejeb/ksoup/html/tokenizer/KsoupTokenizer.kt
+++ b/ksoup-html/src/commonMain/kotlin/com/mohamedrejeb/ksoup/html/tokenizer/KsoupTokenizer.kt
@@ -515,7 +515,7 @@ internal class KsoupTokenizer(
     private fun stateInEntity(c: Int) {
         if (c == CharCodes.Semi.code) {
             val decoded = KsoupEntities.decodeHtml(
-                this.buffer.substring(this.entityStart, this.index + 1)
+                this.buffer.substring(this.entityStart - this.offset, this.index - this.offset + 1)
             )
 
             this.state = this.baseState


### PR DESCRIPTION
when diving the string in TestData.kt in two string, if i parse those string like this:

```
ksoupHtmlParser.write(TestData.htmlStringPart1)
ksoupHtmlParser.write(TestData.htmlStringPart2)
ksoupHtmlParser.end()
```

it will throw an exception because the buffer has only the second string but the index are starting from the first string