### PR TITLE
publicly expose tokenizer callbacks

### DIFF
--- a/ksoup-html/src/commonMain/kotlin/com/mohamedrejeb/ksoup/html/parser/KsoupHtmlOptions.kt
+++ b/ksoup-html/src/commonMain/kotlin/com/mohamedrejeb/ksoup/html/parser/KsoupHtmlOptions.kt
@@ -1,7 +1,5 @@
 package com.mohamedrejeb.ksoup.html.parser
 
-import com.mohamedrejeb.ksoup.html.tokenizer.KsoupTokenizer
-
 public data class KsoupHtmlOptions(
 
     /**

--- a/ksoup-html/src/commonMain/kotlin/com/mohamedrejeb/ksoup/html/tokenizer/KsoupTokenizer.kt
+++ b/ksoup-html/src/commonMain/kotlin/com/mohamedrejeb/ksoup/html/tokenizer/KsoupTokenizer.kt
@@ -6,14 +6,14 @@ import com.mohamedrejeb.ksoup.html.parser.KsoupHtmlParser
 
 /**
  * KsoupTokenizer is an HTML Tokenizer which is able to receive HTML string,
- * breaks it up into individual tokens, and return those tokens with the [Callbacks]
+ * breaks it up into individual tokens, and return those tokens with the [KsoupTokenizerCallbacks]
  *
  * @param options KsoupHtmlOptions
  *
  */
 internal class KsoupTokenizer(
     options: KsoupHtmlOptions,
-    private val callbacks: Callbacks
+    private val callbacks: KsoupTokenizerCallbacks
 ) {
     private val xmlMode = options.xmlMode
     private val decodeEntities = options.decodeEntities
@@ -791,46 +791,6 @@ internal class KsoupTokenizer(
         InSpecialTag,
 
         InEntity,
-    }
-
-    internal interface Callbacks {
-
-        fun onAttribData(
-            start: Int,
-            endIndex: Int
-        )
-
-        fun onAttribEntity(codepoint: Int)
-
-        fun onAttribEnd(quote: KsoupHtmlParser.QuoteType, endIndex: Int)
-
-        fun onAttribName(start: Int, endIndex: Int)
-
-        fun onCData(start: Int, endIndex: Int, offset: Int)
-
-        fun onCloseTag(start: Int, endIndex: Int)
-
-        fun onComment(start: Int, endIndex: Int, offset: Int)
-
-        fun onDeclaration(start: Int, endIndex: Int)
-
-        fun onEnd()
-
-        fun onOpenTagEnd(endIndex: Int)
-
-        fun onOpenTagName(start: Int, endIndex: Int)
-
-        fun onProcessingInstruction(start: Int, endIndex: Int)
-
-        fun onSelfClosingTag(endIndex: Int)
-
-        fun onText(start: Int, endIndex: Int)
-
-        fun onTextEntity(
-            codepoint: Int,
-            endIndex: Int
-        )
-
     }
 
     @OptIn(ExperimentalUnsignedTypes::class)

--- a/ksoup-html/src/commonMain/kotlin/com/mohamedrejeb/ksoup/html/tokenizer/KsoupTokenizerCallbacks.kt
+++ b/ksoup-html/src/commonMain/kotlin/com/mohamedrejeb/ksoup/html/tokenizer/KsoupTokenizerCallbacks.kt
@@ -1,0 +1,189 @@
+package com.mohamedrejeb.ksoup.html.tokenizer
+
+import com.mohamedrejeb.ksoup.html.parser.KsoupHtmlParser
+
+public interface KsoupTokenizerCallbacks {
+
+    public fun onAttribData(start: Int, endIndex: Int) {}
+
+    public fun onAttribEntity(codepoint: Int) {}
+
+    public fun onAttribEnd(quote: KsoupHtmlParser.QuoteType, endIndex: Int) {}
+
+    public fun onAttribName(start: Int, endIndex: Int) {}
+
+    public fun onCData(start: Int, endIndex: Int, offset: Int) {}
+
+    public fun onCloseTag(start: Int, endIndex: Int) {}
+
+    public fun onComment(start: Int, endIndex: Int, offset: Int) {}
+
+    public fun onDeclaration(start: Int, endIndex: Int) {}
+
+    public fun onEnd() {}
+
+    public fun onOpenTagEnd(endIndex: Int) {}
+
+    public fun onOpenTagName(start: Int, endIndex: Int) {}
+
+    public fun onProcessingInstruction(start: Int, endIndex: Int) {}
+
+    public fun onSelfClosingTag(endIndex: Int) {}
+
+    public fun onText(start: Int, endIndex: Int) {}
+
+    public fun onTextEntity(codepoint: Int, endIndex: Int) {}
+
+    public object Default : KsoupTokenizerCallbacks
+
+    public class Builder: KsoupTokenizerCallbacks {
+
+        private var callbacks: KsoupTokenizerCallbacks = KsoupTokenizerCallbacks.Default
+
+        public fun onAttribData(block: (start: Int, endIndex: Int) -> Unit): KsoupTokenizerCallbacks {
+            callbacks = object : KsoupTokenizerCallbacks by callbacks {
+                override fun onAttribData(start: Int, endIndex: Int) {
+                    block(start, endIndex)
+                }
+            }
+            return this
+        }
+
+        public fun onAttribEntity(block: (codepoint: Int) -> Unit): KsoupTokenizerCallbacks {
+            callbacks = object : KsoupTokenizerCallbacks by callbacks {
+                override fun onAttribEntity(codepoint: Int) {
+                    block(codepoint)
+                }
+            }
+            return this
+        }
+
+        public fun onAttribEnd(
+            block: (
+                quote: KsoupHtmlParser.QuoteType,
+                endIndex: Int
+            ) -> Unit
+        ): KsoupTokenizerCallbacks {
+            callbacks = object : KsoupTokenizerCallbacks by callbacks {
+                override fun onAttribEnd(
+                    quote: KsoupHtmlParser.QuoteType,
+                    endIndex: Int
+                ) {
+                    block(quote, endIndex)
+                }
+            }
+            return this
+        }
+
+        public fun onAttribName(block: (start: Int, endIndex: Int) -> Unit): KsoupTokenizerCallbacks {
+            callbacks = object : KsoupTokenizerCallbacks by callbacks {
+                override fun onAttribName(start: Int, endIndex: Int) {
+                    block(start, endIndex)
+                }
+            }
+            return this
+        }
+
+        public fun onCData(block: (start: Int, endIndex: Int, offset: Int) -> Unit): KsoupTokenizerCallbacks {
+            callbacks = object : KsoupTokenizerCallbacks by callbacks {
+                override fun onCData(start: Int, endIndex: Int, offset: Int) {
+                    block(start, endIndex, offset)
+                }
+            }
+            return this
+        }
+
+        public fun onCloseTag(block: (start: Int, endIndex: Int) -> Unit): KsoupTokenizerCallbacks {
+            callbacks = object : KsoupTokenizerCallbacks by callbacks {
+                override fun onCloseTag(start: Int, endIndex: Int) {
+                    block(start, endIndex)
+                }
+            }
+            return this
+        }
+
+        public fun onComment(block: (start: Int, endIndex: Int, offset: Int) -> Unit): KsoupTokenizerCallbacks {
+            callbacks = object : KsoupTokenizerCallbacks by callbacks {
+                override fun onComment(start: Int, endIndex: Int, offset: Int) {
+                    block(start, endIndex, offset)
+                }
+            }
+            return this
+        }
+
+        public fun onDeclaration(block: (start: Int, endIndex: Int) -> Unit): KsoupTokenizerCallbacks {
+            callbacks = object : KsoupTokenizerCallbacks by callbacks {
+                override fun onDeclaration(start: Int, endIndex: Int) {
+                    block(start, endIndex)
+                }
+            }
+            return this
+        }
+
+        public fun onEnd(block: () -> Unit): KsoupTokenizerCallbacks {
+            callbacks = object : KsoupTokenizerCallbacks by callbacks {
+                override fun onEnd() {
+                    block()
+                }
+            }
+            return this
+        }
+
+        public fun onOpenTagEnd(block: (endIndex: Int) -> Unit): KsoupTokenizerCallbacks {
+            callbacks = object : KsoupTokenizerCallbacks by callbacks {
+                override fun onOpenTagEnd(endIndex: Int) {
+                    block(endIndex)
+                }
+            }
+            return this
+        }
+
+        public fun onOpenTagName(block: (start: Int, endIndex: Int) -> Unit): KsoupTokenizerCallbacks {
+            callbacks = object : KsoupTokenizerCallbacks by callbacks {
+                override fun onOpenTagName(start: Int, endIndex: Int) {
+                    block(start, endIndex)
+                }
+            }
+            return this
+        }
+
+        public fun onProcessingInstruction(block: (start: Int, endIndex: Int) -> Unit): KsoupTokenizerCallbacks {
+            callbacks = object : KsoupTokenizerCallbacks by callbacks {
+                override fun onProcessingInstruction(start: Int, endIndex: Int) {
+                    block(start, endIndex)
+                }
+            }
+            return this
+        }
+
+        public fun onSelfClosingTag(block: (endIndex: Int) -> Unit): KsoupTokenizerCallbacks {
+            callbacks = object : KsoupTokenizerCallbacks by callbacks {
+                override fun onSelfClosingTag(endIndex: Int) {
+                    block(endIndex)
+                }
+            }
+            return this
+        }
+
+        public fun onText(block: (start: Int, endIndex: Int) -> Unit): KsoupTokenizerCallbacks {
+            callbacks = object : KsoupTokenizerCallbacks by callbacks {
+                override fun onText(start: Int, endIndex: Int) {
+                    block(start, endIndex)
+                }
+            }
+            return this
+        }
+
+        public fun onTextEntity(block: (codepoint: Int, endIndex: Int) -> Unit): KsoupTokenizerCallbacks {
+            callbacks = object : KsoupTokenizerCallbacks by callbacks {
+                override fun onTextEntity(codepoint: Int, endIndex: Int) {
+                    block(codepoint, endIndex)
+                }
+            }
+            return this
+        }
+
+        public fun build(): KsoupTokenizerCallbacks = callbacks
+
+    }
+}


### PR DESCRIPTION
#### Motivation / Use Case
Been using Ksoup for a while as an alternative to fromHtml on KMP iOS, but I now came across a need to for certain unsupported tags output their entire raw unformatted representation (rather than just emitting their content). 
In this case it is importent they are represented exactly "as is", so I can't just recreate them based on e.g. the attributes parameter. 
Unfortunately for me to be able to handle this case with Ksoup I need to expose some internal state, hence this fork/PR.

There could be many ways Ksoup could allow for this (and similar) use-cases, e.g.:
1. Adjusting `KsoupHtmlHandler` callbacks to include either the "raw" representation of a tag, or corresponding `startIndex` and `endIndex`. Though I suspect this would be seen as out of scope for this library.
2. Making `KsoupHtmlParser` and callback methods `open` rather than `final` (perhaps with some internal state as `protected` to allow subclassers to change the behavior.
3. **The approach this PR goes for**, which is to make the tokenizer callbacks a public interface, and allows passing an instance of them to `KsoupHtmlParser` which gets called (in addition to its own internal one).

#### Changes made:
- Moves tokenizer callbacks to a separate file/class (called `KsoupTokenizerCallbacks`) and makes them public
- Allows (optionally) passing tokenizer callbacks to `KsoupHtmlParser` in addition to existing `KsoupHtmlHandler` 
- Moves from direct inheritance of tokenizer callbacks in `KsoupHtmlParser` to inner (anonymous) object as I don't see why they should be publicly exposed? (could invite calling methods that could mess up internal state?)
